### PR TITLE
Fix query error that prevented database cleanup

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
                     "); "))
             qFatal("Unable to create table 'activation': %s", q.lastError().text().toUtf8().constData());
 
-        if (!q.exec("DELETE FROM query WHERE julianday('now')-julianday(timestamp)>30; "))
+        if (!q.exec("DELETE FROM query WHERE julianday('now')-julianday(timestamp, 'unixepoch')>30; "))
             qWarning("Unable to cleanup 'query' table.");
 
         if (!q.exec("CREATE TABLE IF NOT EXISTS conf(key TEXT UNIQUE, value TEXT); "))


### PR DESCRIPTION
I noticed that my database file got quite large. The reason for that was that all queries I ever made were still saved. The reason is that `julianday(timestamp)` always returns `NULL`. The same problem is already fixed in the [query manager](https://github.com/albertlauncher/albert/blob/dev/src/app/querymanager.cpp#L237).